### PR TITLE
Fix/improve exception parsing

### DIFF
--- a/configuration/src/main/java/org/jahia/loganalyzer/configuration/LogParserConfiguration.java
+++ b/configuration/src/main/java/org/jahia/loganalyzer/configuration/LogParserConfiguration.java
@@ -59,7 +59,7 @@ public class LogParserConfiguration {
     private static final String DEFAULT_DATE_FORMAT_STRING = "yyyy-MM-dd HH:mm:ss,SSS";
     private static final String EXCEPTION_SECONDLINE_PATTERN_STRING = "\\s*(?:(?:at (.*)\\(.*\\))|(?:\\.{3}\\s\\d*\\smore))";
     private static final String EXCEPTION_CAUSEDBY_PATTERN_STRING = "^Caused by: (.*)?$";
-    private static final String EXCEPTION_FIRSTLINE_PATTERN_STRING = "^(\\S*?Exception.*?)(:.*)?$";
+    private static final String EXCEPTION_FIRSTLINE_PATTERN_STRING = ".*?(\\w+(?:\\.\\w+)*\\.\\w*Exception\\S*)(?:: (.*))?$";
     private static final String OLDER_PERF_MATCHING_PATTERN_STRING = ".*?\\[(.*?)\\].*org\\.jahia\\.bin\\.Jahia.*Processed \\[(.*?)\\](?: esi=\\[(.*?)\\])? user=\\[(.*)\\] ip=\\[(.*)\\] in \\[(.*)ms\\].*";
     private static final String OLD_PERF_MATCHING_PATTERN_STRING = "(.*?): .*\\[org\\.jahia\\.bin\\.Jahia\\].*Processed \\[(.*?)\\](?: esi=\\[(.*?)\\])? user=\\[(.*)\\] ip=\\[(.*)\\] in \\[(.*)ms\\].*";
     private static final String PERF_MATCHING_PATTERN_STRING = "(.*?): .*\\[Render].*Rendered \\[(.*?)\\](?: esi=\\[(.*?)\\])? user=\\[(.*)\\] ip=\\[(.*)\\] sessionID=\\[(.*)\\] in \\[(.*)ms\\].*";

--- a/configuration/src/main/resources/parser-config.xml
+++ b/configuration/src/main/resources/parser-config.xml
@@ -31,7 +31,7 @@
             <matching-pattern>(.*?): .*\[Render].*Rendered \[(.*?)\](?: esi=\[(.*?)\])? user=\[(.*)\] ip=\[(.*)\] sessionID=\[(.*)\] in \[(.*)ms\].*</matching-pattern>
         </perf-analyzer>
         <exception-analyzer>
-            <firstline-pattern>^(\S*?Exception.*?)(:.*)?$</firstline-pattern>
+            <firstline-pattern>.*?(\w+(?:\.\w+)*\.\w*Exception\S*)(?:: (.*))?$</firstline-pattern>
             <secondline-pattern>\s*(?:(?:at (.*)\(.*\))|(?:\.{3}\s\d*\smore))</secondline-pattern>
             <causedby-pattern>^Caused by: (.*)?$</causedby-pattern>
         </exception-analyzer>

--- a/lineanalyzers/standard/src/main/java/org/jahia/loganalyzer/lineanalyzers/standard/exceptions/ExceptionSummaryLogEntry.java
+++ b/lineanalyzers/standard/src/main/java/org/jahia/loganalyzer/lineanalyzers/standard/exceptions/ExceptionSummaryLogEntry.java
@@ -74,7 +74,7 @@ public class ExceptionSummaryLogEntry extends BaseLogEntry {
         LinkedHashMap<String, Object> result = super.getValues();
         result.put("count", count);
         result.put("className", (exceptionDetailsLogEntry != null ? exceptionDetailsLogEntry.getClassName() : null));
-        result.put("message", (exceptionDetailsLogEntry != null ? exceptionDetailsLogEntry.getClassName() : null));
+        result.put("message", (exceptionDetailsLogEntry != null ? exceptionDetailsLogEntry.getMessage() : null));
         result.put("stackTrace", (exceptionDetailsLogEntry != null ? exceptionDetailsLogEntry.getStackTrace() : null));
         result.put("contextLines", (exceptionDetailsLogEntry != null ? exceptionDetailsLogEntry.getContextLines() : null));
         return result;


### PR DESCRIPTION
Fix NPE, which completely stopped log parsing, as inException in
parseLine was set too early.
Fix exception summary to not write classname to message field.
Refactor isForThisAnalyzer/parseLog and regular expressions to:
- detect exceptions within a standard log or in own new line
- handle exceptions with or without detail messages, which can go over
multiple lines
- handle exceptions with or without stacktrace
- skip one line if exception class and detail message is printed twice
- ignore corrupted single lines within an exception stacktrace
- write number of found exceptions to the log at the end